### PR TITLE
Add Dvorak layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ output directly).
 ## Supports:
 
 * Scancode Set 1 and 2
+* Dvorak 104-key layout
 * US 104-key layout
 * UK 105-key layout
 * JIS 109-key layout

--- a/src/layouts/dvorak104.rs
+++ b/src/layouts/dvorak104.rs
@@ -30,27 +30,21 @@ impl KeyboardLayout for Dvorak104Key {
                 }
             }
             KeyCode::Q => {
-                if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0011}')
-                } else if modifiers.is_caps() {
+                if modifiers.is_caps() {
                     DecodedKey::Unicode('"')
                 } else {
                     DecodedKey::Unicode('\'')
                 }
             }
             KeyCode::W => {
-                if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0017}')
-                } else if modifiers.is_caps() {
+                if modifiers.is_caps() {
                     DecodedKey::Unicode('<')
                 } else {
                     DecodedKey::Unicode(',')
                 }
             }
             KeyCode::E => {
-                if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0005}')
-                } else if modifiers.is_caps() {
+                if modifiers.is_caps() {
                     DecodedKey::Unicode('>')
                 } else {
                     DecodedKey::Unicode('.')
@@ -58,7 +52,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::R => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0012}')
+                    DecodedKey::Unicode('\u{0010}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('P')
                 } else {
@@ -67,7 +61,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::T => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0014}')
+                    DecodedKey::Unicode('\u{0019}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('Y')
                 } else {
@@ -76,7 +70,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::Y => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0019}')
+                    DecodedKey::Unicode('\u{0006}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('F')
                 } else {
@@ -85,7 +79,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::U => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0015}')
+                    DecodedKey::Unicode('\u{0007}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('G')
                 } else {
@@ -94,7 +88,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::I => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0009}')
+                    DecodedKey::Unicode('\u{0003}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('C')
                 } else {
@@ -103,7 +97,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::O => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{000F}')
+                    DecodedKey::Unicode('\u{0012}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('R')
                 } else {
@@ -112,7 +106,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::P => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0010}')
+                    DecodedKey::Unicode('\u{000C}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('L')
                 } else {
@@ -135,7 +129,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::S => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0013}')
+                    DecodedKey::Unicode('\u{000F}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('O')
                 } else {
@@ -144,7 +138,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::D => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0004}')
+                    DecodedKey::Unicode('\u{0005}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('E')
                 } else {
@@ -153,7 +147,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::F => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0006}')
+                    DecodedKey::Unicode('\u{0015}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('U')
                 } else {
@@ -162,7 +156,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::G => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0007}')
+                    DecodedKey::Unicode('\u{0009}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('I')
                 } else {
@@ -171,7 +165,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::H => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0008}')
+                    DecodedKey::Unicode('\u{0004}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('D')
                 } else {
@@ -180,7 +174,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::J => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{000A}')
+                    DecodedKey::Unicode('\u{0008}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('H')
                 } else {
@@ -189,7 +183,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::K => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{000B}')
+                    DecodedKey::Unicode('\u{0014}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('T')
                 } else {
@@ -198,7 +192,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::L => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{000C}')
+                    DecodedKey::Unicode('\u{000E}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('N')
                 } else {
@@ -206,7 +200,9 @@ impl KeyboardLayout for Dvorak104Key {
                 }
             }
             KeyCode::SemiColon => {
-                if modifiers.is_shifted() {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0013}')
+                } else if modifiers.is_shifted() {
                     DecodedKey::Unicode('S')
                 } else {
                     DecodedKey::Unicode('s')
@@ -220,9 +216,7 @@ impl KeyboardLayout for Dvorak104Key {
                 }
             }
             KeyCode::Z => {
-                if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{001A}')
-                } else if modifiers.is_caps() {
+                if modifiers.is_caps() {
                     DecodedKey::Unicode(':')
                 } else {
                     DecodedKey::Unicode(';')
@@ -230,7 +224,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::X => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0018}')
+                    DecodedKey::Unicode('\u{0011}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('Q')
                 } else {
@@ -239,7 +233,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::C => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0003}')
+                    DecodedKey::Unicode('\u{000A}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('J')
                 } else {
@@ -248,7 +242,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::V => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0016}')
+                    DecodedKey::Unicode('\u{000B}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('K')
                 } else {
@@ -257,7 +251,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::B => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0002}')
+                    DecodedKey::Unicode('\u{0018}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('X')
                 } else {
@@ -266,7 +260,7 @@ impl KeyboardLayout for Dvorak104Key {
             }
             KeyCode::N => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{000E}')
+                    DecodedKey::Unicode('\u{0002}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('B')
                 } else {
@@ -274,21 +268,27 @@ impl KeyboardLayout for Dvorak104Key {
                 }
             }
             KeyCode::Comma => {
-                if modifiers.is_shifted() {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0017}')
+                } else if modifiers.is_shifted() {
                     DecodedKey::Unicode('W')
                 } else {
                     DecodedKey::Unicode('w')
                 }
             }
             KeyCode::Fullstop => {
-                if modifiers.is_shifted() {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0016}')
+                } else if modifiers.is_shifted() {
                     DecodedKey::Unicode('V')
                 } else {
                     DecodedKey::Unicode('v')
                 }
             }
             KeyCode::Slash => {
-                if modifiers.is_shifted() {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{001A}')
+                } else if modifiers.is_shifted() {
                     DecodedKey::Unicode('Z')
                 } else {
                     DecodedKey::Unicode('z')

--- a/src/layouts/dvorak104.rs
+++ b/src/layouts/dvorak104.rs
@@ -30,21 +30,21 @@ impl KeyboardLayout for Dvorak104Key {
                 }
             }
             KeyCode::Q => {
-                if modifiers.is_caps() {
+                if modifiers.is_shifted() {
                     DecodedKey::Unicode('"')
                 } else {
                     DecodedKey::Unicode('\'')
                 }
             }
             KeyCode::W => {
-                if modifiers.is_caps() {
+                if modifiers.is_shifted() {
                     DecodedKey::Unicode('<')
                 } else {
                     DecodedKey::Unicode(',')
                 }
             }
             KeyCode::E => {
-                if modifiers.is_caps() {
+                if modifiers.is_shifted() {
                     DecodedKey::Unicode('>')
                 } else {
                     DecodedKey::Unicode('.')
@@ -202,7 +202,7 @@ impl KeyboardLayout for Dvorak104Key {
             KeyCode::SemiColon => {
                 if map_to_unicode && modifiers.is_ctrl() {
                     DecodedKey::Unicode('\u{0013}')
-                } else if modifiers.is_shifted() {
+                } else if modifiers.is_caps() {
                     DecodedKey::Unicode('S')
                 } else {
                     DecodedKey::Unicode('s')
@@ -216,7 +216,7 @@ impl KeyboardLayout for Dvorak104Key {
                 }
             }
             KeyCode::Z => {
-                if modifiers.is_caps() {
+                if modifiers.is_shifted() {
                     DecodedKey::Unicode(':')
                 } else {
                     DecodedKey::Unicode(';')
@@ -270,7 +270,7 @@ impl KeyboardLayout for Dvorak104Key {
             KeyCode::Comma => {
                 if map_to_unicode && modifiers.is_ctrl() {
                     DecodedKey::Unicode('\u{0017}')
-                } else if modifiers.is_shifted() {
+                } else if modifiers.is_caps() {
                     DecodedKey::Unicode('W')
                 } else {
                     DecodedKey::Unicode('w')
@@ -279,7 +279,7 @@ impl KeyboardLayout for Dvorak104Key {
             KeyCode::Fullstop => {
                 if map_to_unicode && modifiers.is_ctrl() {
                     DecodedKey::Unicode('\u{0016}')
-                } else if modifiers.is_shifted() {
+                } else if modifiers.is_caps() {
                     DecodedKey::Unicode('V')
                 } else {
                     DecodedKey::Unicode('v')
@@ -288,7 +288,7 @@ impl KeyboardLayout for Dvorak104Key {
             KeyCode::Slash => {
                 if map_to_unicode && modifiers.is_ctrl() {
                     DecodedKey::Unicode('\u{001A}')
-                } else if modifiers.is_shifted() {
+                } else if modifiers.is_caps() {
                     DecodedKey::Unicode('Z')
                 } else {
                     DecodedKey::Unicode('z')

--- a/src/layouts/dvorak104.rs
+++ b/src/layouts/dvorak104.rs
@@ -1,0 +1,290 @@
+//! A Dvorak 101-key (or 104-key including Windows keys) keyboard.
+//! Has a 1-row high Enter key, with Backslash above.
+
+use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
+
+pub use super::us104::Us104Key;
+
+pub struct Dvorak104Key;
+
+impl KeyboardLayout for Dvorak104Key {
+    fn map_keycode(
+        keycode: KeyCode,
+        modifiers: &Modifiers,
+        handle_ctrl: HandleControl,
+    ) -> DecodedKey {
+        match keycode {
+            KeyCode::Minus => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('{')
+                } else {
+                    DecodedKey::Unicode('[')
+                }
+            }
+            KeyCode::Equals => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('}')
+                } else {
+                    DecodedKey::Unicode(']')
+                }
+            }
+            KeyCode::Q => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0011}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('"')
+                } else {
+                    DecodedKey::Unicode('\'')
+                }
+            }
+            KeyCode::W => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0017}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('<')
+                } else {
+                    DecodedKey::Unicode(',')
+                }
+            }
+            KeyCode::E => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0005}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('>')
+                } else {
+                    DecodedKey::Unicode('.')
+                }
+            }
+            KeyCode::R => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0012}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('P')
+                } else {
+                    DecodedKey::Unicode('p')
+                }
+            }
+            KeyCode::T => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0014}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('Y')
+                } else {
+                    DecodedKey::Unicode('y')
+                }
+            }
+            KeyCode::Y => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0019}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('F')
+                } else {
+                    DecodedKey::Unicode('f')
+                }
+            }
+            KeyCode::U => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0015}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('G')
+                } else {
+                    DecodedKey::Unicode('g')
+                }
+            }
+            KeyCode::I => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0009}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('C')
+                } else {
+                    DecodedKey::Unicode('c')
+                }
+            }
+            KeyCode::O => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000F}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('R')
+                } else {
+                    DecodedKey::Unicode('r')
+                }
+            }
+            KeyCode::P => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0010}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('L')
+                } else {
+                    DecodedKey::Unicode('l')
+                }
+            }
+            KeyCode::BracketSquareLeft => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('?')
+                } else {
+                    DecodedKey::Unicode('/')
+                }
+            }
+            KeyCode::BracketSquareRight => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('+')
+                } else {
+                    DecodedKey::Unicode('=')
+                }
+            }
+            KeyCode::D => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0004}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('E')
+                } else {
+                    DecodedKey::Unicode('e')
+                }
+            }
+            KeyCode::F => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0006}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('U')
+                } else {
+                    DecodedKey::Unicode('u')
+                }
+            }
+            KeyCode::G => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0007}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('I')
+                } else {
+                    DecodedKey::Unicode('i')
+                }
+            }
+            KeyCode::H => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0008}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('D')
+                } else {
+                    DecodedKey::Unicode('d')
+                }
+            }
+            KeyCode::J => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000A}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('H')
+                } else {
+                    DecodedKey::Unicode('h')
+                }
+            }
+            KeyCode::K => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000B}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('T')
+                } else {
+                    DecodedKey::Unicode('t')
+                }
+            }
+            KeyCode::L => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000C}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('N')
+                } else {
+                    DecodedKey::Unicode('n')
+                }
+            }
+            KeyCode::SemiColon => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('S')
+                } else {
+                    DecodedKey::Unicode('s')
+                }
+            }
+            KeyCode::Quote => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('_')
+                } else {
+                    DecodedKey::Unicode('-')
+                }
+            }
+            KeyCode::Z => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{001A}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode(':')
+                } else {
+                    DecodedKey::Unicode(';')
+                }
+            }
+            KeyCode::X => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0018}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('Q')
+                } else {
+                    DecodedKey::Unicode('q')
+                }
+            }
+            KeyCode::C => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0003}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('J')
+                } else {
+                    DecodedKey::Unicode('j')
+                }
+            }
+            KeyCode::V => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0016}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('K')
+                } else {
+                    DecodedKey::Unicode('k')
+                }
+            }
+            KeyCode::B => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0002}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('X')
+                } else {
+                    DecodedKey::Unicode('x')
+                }
+            }
+            KeyCode::N => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000E}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('B')
+                } else {
+                    DecodedKey::Unicode('b')
+                }
+            }
+            KeyCode::Comma => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('W')
+                } else {
+                    DecodedKey::Unicode('w')
+                }
+            }
+            KeyCode::Fullstop => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('V')
+                } else {
+                    DecodedKey::Unicode('v')
+                }
+            }
+            KeyCode::Slash => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('Z')
+                } else {
+                    DecodedKey::Unicode('z')
+                }
+            }
+            e => <super::Us104Key as KeyboardLayout>::map_keycode(e, modifiers, handle_ctrl),
+        }
+    }
+}

--- a/src/layouts/dvorak104.rs
+++ b/src/layouts/dvorak104.rs
@@ -133,6 +133,15 @@ impl KeyboardLayout for Dvorak104Key {
                     DecodedKey::Unicode('=')
                 }
             }
+            KeyCode::S => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0013}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('O')
+                } else {
+                    DecodedKey::Unicode('o')
+                }
+            }
             KeyCode::D => {
                 if map_to_unicode && modifiers.is_ctrl() {
                     DecodedKey::Unicode('\u{0004}')

--- a/src/layouts/dvorak104.rs
+++ b/src/layouts/dvorak104.rs
@@ -13,6 +13,7 @@ impl KeyboardLayout for Dvorak104Key {
         modifiers: &Modifiers,
         handle_ctrl: HandleControl,
     ) -> DecodedKey {
+        let map_to_unicode = handle_ctrl == HandleControl::MapLettersToUnicode;
         match keycode {
             KeyCode::Minus => {
                 if modifiers.is_shifted() {

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -4,6 +4,9 @@
 //! handle all the 'different' keys first, and then jump to another handler -
 //! see UK105 and US104 as an example of that.
 
+mod dvorak104;
+pub use self::dvorak104::Dvorak104Key;
+
 mod us104;
 pub use self::us104::Us104Key;
 


### PR DESCRIPTION
Hello, I started coding a toy OS and your crate is really helpful, thanks!

I use a [Dvorak layout](https://en.wikipedia.org/wiki/Dvorak_keyboard_layout) so I created one by copying the US 104 layout and keeping only the diff, like the code of the UK 105 layout does.

I didn't change any of the `ctrl` modifiers, not sure if I should? I don't use that on my keyboards so I don't really know.